### PR TITLE
Add support for Enchantment Descriptions.

### DIFF
--- a/common/src/main/resources/assets/biomemakeover/lang/en_us.json
+++ b/common/src/main/resources/assets/biomemakeover/lang/en_us.json
@@ -22,6 +22,18 @@
   "enchantment.biomemakeover.unwieldiness_curse" : "Curse of Unwieldiness",
   "enchantment.biomemakeover.inaccuracy_curse" : "Curse of Inaccuracy",
   "enchantment.biomemakeover.buckling_curse": "Curse of Buckling",
+  
+  "enchantment.biomemakeover.decay_curse.desc" : "Items degrade faster.",
+  "enchantment.biomemakeover.enfeeblement_curse.desc" : "Reduces your maximum health.",
+  "enchantment.biomemakeover.insomnia_curse.desc" : "Phantoms appear faster.",
+  "enchantment.biomemakeover.conductivity_curse.desc" : "Attracts lighting during storms.",
+  "enchantment.biomemakeover.sliding_curse.desc" : "You sometimes slide around.",
+  "enchantment.biomemakeover.depth_curse.desc" : "You sink faster in water.",
+  "enchantment.biomemakeover.flammability_curse.desc" : "Burning lasts longer.",
+  "enchantment.biomemakeover.suffocation_curse.desc" : "Reduces your maximum oxygen under water.",
+  "enchantment.biomemakeover.unwieldiness_curse.desc" : "Slows down your attack speed.",
+  "enchantment.biomemakeover.inaccuracy_curse.desc" : "Reduces projectile accuracy.",
+  "enchantment.biomemakeover.buckling_curse.desc": "Increases fall damage.",
 
   "effect.biomemakeover.shocked" : "Shocked",
   "effect.biomemakeover.antidote" : "Antidote",


### PR DESCRIPTION
Hello, I've had a few players reach out about adding compatibility for [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions). I was going to add it on my end but felt it would be better to implement here so that you have better control over the information being displayed to players.   