### PR TITLE
Fix thread safety with mob spawning/creation

### DIFF
--- a/common/src/main/java/party/lemons/biomemakeover/entity/DecayedEntity.java
+++ b/common/src/main/java/party/lemons/biomemakeover/entity/DecayedEntity.java
@@ -143,10 +143,10 @@ public class DecayedEntity extends Zombie
         {
             stopUsingItem();
             setItemInHand(InteractionHand.OFF_HAND, ItemStack.EMPTY);
-            playSound(SoundEvents.SHIELD_BREAK, 0.8F, 0.8F + this.level.random.nextFloat() * 0.4F);
+            playSound(SoundEvents.SHIELD_BREAK, 0.8F, 0.8F + this.random.nextFloat() * 0.4F);
         }else
         {
-            this.playSound(SoundEvents.SHIELD_BLOCK, 1.0F, 0.8F + this.level.random.nextFloat() * 0.4F);
+            this.playSound(SoundEvents.SHIELD_BLOCK, 1.0F, 0.8F + this.random.nextFloat() * 0.4F);
             shieldDisableTime = Math.max((int) (13F + (amount * 3F)), shieldDisableTime);
         }
     }

--- a/common/src/main/java/party/lemons/biomemakeover/entity/LightningBugEntity.java
+++ b/common/src/main/java/party/lemons/biomemakeover/entity/LightningBugEntity.java
@@ -60,7 +60,7 @@ public class LightningBugEntity extends ToadTargetEntity implements FlyingAnimal
         this.setPathfindingMalus(BlockPathTypes.WATER_BORDER, 16.0F);
         this.setPathfindingMalus(BlockPathTypes.COCOA, -1.0F);
         this.setPathfindingMalus(BlockPathTypes.FENCE, -1.0F);
-        tickCount += level.random.nextInt(10000);
+        tickCount += this.random.nextInt(10000);
     }
 
     public LightningBugEntity(Level level, boolean isAlternate)
@@ -200,7 +200,7 @@ public class LightningBugEntity extends ToadTargetEntity implements FlyingAnimal
     public void tick()
     {
         super.tick();
-        if(this.hasOthersInGroup() && this.level.random.nextInt(200) == 1)
+        if(this.hasOthersInGroup() && this.random.nextInt(200) == 1)
         {
             List<LightningBugEntity> list = this.level.getEntitiesOfClass(LightningBugEntity.class, this.getBoundingBox().inflate(8.0D, 8.0D, 8.0D));
             if(list.size() <= 1)

--- a/common/src/main/java/party/lemons/biomemakeover/entity/MothEntity.java
+++ b/common/src/main/java/party/lemons/biomemakeover/entity/MothEntity.java
@@ -293,7 +293,7 @@ public class MothEntity extends Monster
 
         MoveToLightGoal() {
             super();
-            this.ticks = MothEntity.this.level.random.nextInt(10);
+            this.ticks = MothEntity.this.random.nextInt(10);
             this.setFlags(EnumSet.of(Goal.Flag.MOVE));
         }
 

--- a/common/src/main/java/party/lemons/biomemakeover/entity/RootlingEntity.java
+++ b/common/src/main/java/party/lemons/biomemakeover/entity/RootlingEntity.java
@@ -350,7 +350,7 @@ public class RootlingEntity extends Animal implements Shearable, EntityEventBroa
             }
             if(spots.isEmpty()) return null;
 
-            BlockPos pos = spots.get(level.random.nextInt(spots.size()));
+            BlockPos pos = spots.get(RootlingEntity.this.random.nextInt(spots.size()));
             if(pos != null) targetState = level.getBlockState(pos);
 
             return pos;

--- a/common/src/main/java/party/lemons/biomemakeover/entity/ScuttlerEntity.java
+++ b/common/src/main/java/party/lemons/biomemakeover/entity/ScuttlerEntity.java
@@ -425,7 +425,7 @@ public class ScuttlerEntity extends Animal {
                 }
             }
             if(spots.isEmpty()) return null;
-            return spots.get(level.random.nextInt(spots.size()));
+            return spots.get(ScuttlerEntity.this.random.nextInt(spots.size()));
         }
     }
 

--- a/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
+++ b/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
@@ -1,8 +1,6 @@
 package party.lemons.biomemakeover.mixin.mushroom;
 
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.animal.MushroomCow;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,12 +10,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MushroomCow.class)
-public abstract class MushroomCowMixin extends Entity
+public abstract class MushroomCowMixin
 {
-    public MushroomCowMixin(EntityType<? extends Cow> entityType, Level level) {
-        super(entityType, level);
-    }
-
     @Shadow public abstract MushroomCow.MushroomType getMushroomType();
 
     @Shadow protected abstract void setMushroomType(MushroomCow.MushroomType mushroomType);
@@ -26,7 +20,7 @@ public abstract class MushroomCowMixin extends Entity
     public void onContruct(EntityType<? extends MushroomCow> type, Level level, CallbackInfo cbi)
     {
         if(getMushroomType() != MushroomCow.MushroomType.BROWN)
-            if(this.random.nextBoolean())
+            if(((MushroomCow)(Object)this).getRandom().nextBoolean())
                 setMushroomType(MushroomCow.MushroomType.BROWN);
     }
 }

--- a/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
+++ b/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
@@ -1,6 +1,7 @@
 package party.lemons.biomemakeover.mixin.mushroom;
 
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.animal.MushroomCow;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,8 +11,12 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MushroomCow.class)
-public abstract class MushroomCowMixin
+public abstract class MushroomCowMixin extends Cow
 {
+    public MushroomCowMixin(EntityType<? extends Cow> entityType, Level level) {
+        super(entityType, level);
+    }
+
     @Shadow public abstract MushroomCow.MushroomType getMushroomType();
 
     @Shadow protected abstract void setMushroomType(MushroomCow.MushroomType mushroomType);
@@ -20,7 +25,7 @@ public abstract class MushroomCowMixin
     public void onContruct(EntityType<? extends MushroomCow> type, Level level, CallbackInfo cbi)
     {
         if(getMushroomType() != MushroomCow.MushroomType.BROWN)
-            if(level.random.nextBoolean())
+            if(this.random.nextBoolean())
                 setMushroomType(MushroomCow.MushroomType.BROWN);
     }
 }

--- a/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
+++ b/common/src/main/java/party/lemons/biomemakeover/mixin/mushroom/MushroomCowMixin.java
@@ -1,5 +1,6 @@
 package party.lemons.biomemakeover.mixin.mushroom;
 
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.animal.MushroomCow;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MushroomCow.class)
-public abstract class MushroomCowMixin extends Cow
+public abstract class MushroomCowMixin extends Entity
 {
     public MushroomCowMixin(EntityType<? extends Cow> entityType, Level level) {
         super(entityType, level);


### PR DESCRIPTION
A user was reporting that the Moth in Biome Makeover was crashing when the game was spawning it during worldgen: https://mclo.gs/aUscAv0

Basically you're getting the same issue as this: https://github.com/team-abnormals/savage-and-ravage/issues/119

Short summary, if you are in a spot for entities that could run in the off thread (not server thread such as worldgen which is on its own thread), do not use the level's randomsource. Use the entity's own personal randomsource.

You will need to port the fix to 1.19.3 which should just be a simple easy cherrypicking. Hope this helps 