### PR TITLE
Use a thread-safe RandomSource in RandomUtil

### DIFF
--- a/common/src/main/java/party/lemons/biomemakeover/util/RandomUtil.java
+++ b/common/src/main/java/party/lemons/biomemakeover/util/RandomUtil.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 public final class RandomUtil
 {
-    public static final RandomSource RANDOM = RandomSource.create();
+    public static final RandomSource RANDOM = RandomSource.createThreadSafe();
 
     public static int randomRange(int min, int max)
     {


### PR DESCRIPTION
RandomUtil may be accessed by multiple threads at the same time. This can cause errors. For example, spawning a rootling with C2ME installed:
```
[06:27:50] [C2ME worker #1/WARN] (Minecraft) Failed to create mob
net.minecraft.class_148: Accessing LegacyRandomSource from multiple threads
	at net.minecraft.class_5798.method_33564(class_5798.java:88) ~[minecraft-1.20.1.i0:0/:?]
	at net.minecraft.class_5820.method_43156(class_5820.java:49) ~[minecraft-1.20.1.i0:0/:?]
	at net.minecraft.class_6566.method_43048(class_6566.java:33) ~[minecraft-1.20.1.i0:0/:?]
	at party.lemons.biomemakeover.util.RandomUtil.randomRange(RandomUtil.java:14) ~[biomemakeover-1.20.1-1.11.4.i0:0/:?]
	at party.lemons.biomemakeover.entity.RootlingEntity.<init>(RootlingEntity.java:69) ~[biomemakeover-1.20.1-1.11.4.i0:0/:?]
	at net.minecraft.class_1299.method_5883(class_1299.java:544) ~[minecraft-1.20.1.i0:0/:?]
	at net.minecraft.class_1948.method_8661(class_1948.java:518) ~[minecraft-1.20.1.i0:0/:?]
	at net.minecraft.class_3754.method_12107(class_3754.java:453) ~[minecraft-1.20.1.i0:0/:?]
	at net.minecraft.class_2806.method_17033(class_2806.java:140) ~[minecraft-1.20.1.i0:0/:?]
```
Note that `createThreadSafe` is marked as deprecated. I think this is because sharing RandomSources like this is bad practice because it's no longer deterministic. Avoiding that is a significant refactor though, so this will do.